### PR TITLE
Enable Renovate with 3-day release age and patch/minor automerge

### DIFF
--- a/.github/workflows/spring-boot-webflux-kotlin-coroutine.yml
+++ b/.github/workflows/spring-boot-webflux-kotlin-coroutine.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
       - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 jobs:
   test:

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "baseBranches": [
+    "develop"
+  ],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "platformAutomerge": false,
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "addLabels": [
+        "automerge"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "addLabels": [
+        "major-update"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Renovate configuration so dependency updates are raised automatically, restricted to releases that have been public for at least 3 days. Patch and minor updates automerge once CI is green, while major updates are always left for a human to review and merge.

## Background / Motivation

- Dependency bumps here are done by hand — see the `Upgrade Spring to 3.4.2 and JDK21 compatible` and `Update gradle to 8.12` commits — so versions drift until someone notices.
- Adopting a release the day it ships risks pulling in a version that gets withdrawn or hotfixed shortly after. A short soak period filters most of those out.
- The CI workflow only triggered on `push` to `master` and `develop`, so no pull request in this repository ever ran checks. Renovate treats a branch with zero checks as green, so patch/minor automerge would have merged dependency bumps with no tests run at all.
- `develop` has no branch protection, so GitHub's native auto-merge sees no blockers on a Renovate PR and can merge it before CI reports back.

## Changes

### Renovate configuration

- New `renovate.json` extending `config:recommended`, with `baseBranches` pinned to `develop`, this repository's default branch.
- `minimumReleaseAge: "3 days"` together with `internalChecksFilter: "strict"`, so an update is only proposed once its release is at least 3 days old.
- `packageRules` entry matching `patch` and `minor`: `automerge: true` with `automergeType: "pr"` and an `automerge` label.
- `packageRules` entry matching `major`: `automerge: false` plus a `major-update` label, so these surface for manual review and merge.

### CI coverage for Renovate PRs

- `.github/workflows/spring-boot-webflux-kotlin-coroutine.yml` gains a `pull_request` trigger for `master` and `develop`, so the existing `Run Test` job (`./gradlew clean build`) runs on Renovate's PRs before automerge is considered.

### Automerge safety

- `platformAutomerge: false` keeps merging under Renovate's own control rather than GitHub's auto-merge, so check results are verified before the merge even without branch protection on `develop`.

## Verification

The official validator accepts the config:

```
npx --yes --package renovate renovate-config-validator renovate.json
# INFO: Config validated successfully against 1 file(s)
```

Once the Renovate GitHub App is installed, its pull requests should show the `Run Test` check running, patch/minor PRs should carry the `automerge` label, and major PRs should carry `major-update` and stay open.

## Test plan

- [ ] `npx --yes --package renovate renovate-config-validator renovate.json` reports `Config validated successfully`.
- [ ] This PR itself shows the `Run Test` check, confirming the new `pull_request` trigger fires.
- [ ] Install the Renovate GitHub App and merge the onboarding PR it opens.
- [ ] A patch/minor Renovate PR runs `Run Test` and automerges only after it passes.
- [ ] A major Renovate PR is labelled `major-update` and is left unmerged.
- [ ] No Renovate PR is raised for a release published less than 3 days ago.

## Follow-up

Renovate will not run from this config alone. The GitHub App must be installed for this repository at https://github.com/apps/renovate; Renovate then opens an onboarding PR, and merging it activates the configuration.
