### PR TITLE
Upgrade to Spring Boot 4.1, Kotlin 2.3 and Java 25 managed by mise

### DIFF
--- a/.github/workflows/spring-boot-webflux-kotlin-coroutine.yml
+++ b/.github/workflows/spring-boot-webflux-kotlin-coroutine.yml
@@ -19,11 +19,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '21'
+      - name: Set up toolchain
+        uses: jdx/mise-action@v4 # Installs the Java version pinned in mise.toml
 
       - name: Install dependencies, run tests, and collect coverage
         run: ./gradlew clean build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container in which to build the application
-FROM gradle:8.12-jdk21-alpine as builder
+FROM gradle:9.5.1-jdk25 AS builder
 
 # Copy the source code into the builder container
 WORKDIR /app
@@ -9,7 +9,7 @@ COPY . .
 RUN gradle assemble
 
 # Container in which to run the application
-FROM eclipse-temurin:21.0.11_10-jdk-ubi9-minimal
+FROM eclipse-temurin:25.0.3_9-jdk-ubi10-minimal
 
 # Copy the jar from the builder container into the run container
 COPY --from=builder /app/build/libs/spring-boot-webflux-kotlin-coroutine-*.jar spring-boot-webflux-kotlin-coroutine.jar

--- a/README.md
+++ b/README.md
@@ -5,12 +5,22 @@
 A sample of Spring boot WebFlux and Kotlin Coroutine with Handler and Router. In this sample, implementing Todo model, handler and router with database (MySQL) testing.
 
 # Reqirements
-- Java 21
+- Java 25 (managed by [mise](https://mise.jdx.dev/))
 - Docker 4.37.2 >=
-- gradle 8.12 >=
+- gradle 9.5.1 (provided by the Gradle wrapper)
+
+Spring Boot 4.1 / Kotlin 2.3 / Spring Framework 7.
 
 # Getting Started
 Please make sure Docker is up and running.
+
+## Toolchain setup
+The JDK is pinned in `mise.toml`. Install it with:
+```bash
+$ mise trust
+$ mise install
+```
+`mise` then puts Java 25 on the `PATH` and sets `JAVA_HOME` for this directory.
 
 ## Production
 ```bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,94 +1,84 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     java
     jacoco
-	id("org.springframework.boot") version "3.4.2"
+	id("org.springframework.boot") version "4.1.0"
 	id("io.spring.dependency-management") version "1.1.7"
     id("org.springdoc.openapi-gradle-plugin") version "1.9.0"
-    id("org.openapi.generator") version "7.10.0"
 
-    kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
+    kotlin("jvm") version "2.3.21"
+	kotlin("plugin.spring") version "2.3.21"
 }
 
 group = "com.sennproject"
 version = "1.0.0"
-java.sourceCompatibility = JavaVersion.VERSION_21
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
-extra["kotestVersion"] = "5.9.1"
-extra["openAPIVersion"] = "2.8.4"
-extra["testcontainersVersion"] = "1.20.4"
-extra["coroutinesCoreVersion"] = "1.10.1"
+extra["kotestVersion"] = "6.2.2"
+extra["openAPIVersion"] = "3.0.3"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${property("coroutinesCoreVersion")}")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.springframework:spring-jdbc")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
 
-    // Lombok
-    compileOnly("org.projectlombok:lombok")
-    annotationProcessor("org.projectlombok:lombok")
-    
     // OpenAPI
-    implementation("org.springframework.cloud:spring-cloud-function-web:4.2.1")
     implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:${property("openAPIVersion")}")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // Database
-    implementation("io.r2dbc:r2dbc-pool:1.0.2.RELEASE")
+    implementation("io.r2dbc:r2dbc-pool")
     implementation("org.springframework.data:spring-data-commons")
     implementation("org.springframework.data:spring-data-relational")
-    implementation("org.postgresql:r2dbc-postgresql:1.0.7.RELEASE")
+    implementation("org.postgresql:r2dbc-postgresql")
 
     // Test
     testImplementation("io.kotest:kotest-runner-junit5:${property("kotestVersion")}")
     testImplementation("io.kotest:kotest-assertions-core:${property("kotestVersion")}")
+    testImplementation("io.kotest:kotest-assertions-table:${property("kotestVersion")}")
     testImplementation("io.kotest:kotest-property:${property("kotestVersion")}")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${property("coroutinesCoreVersion")}")
-    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+    testImplementation("io.kotest:kotest-extensions-spring:${property("kotestVersion")}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-data-r2dbc-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("io.projectreactor:reactor-test")
-    testImplementation("org.testcontainers:junit-jupiter:${property("testcontainersVersion")}")
-    testImplementation("org.testcontainers:postgresql:${property("testcontainersVersion")}")
-    testImplementation("org.testcontainers:r2dbc:${property("testcontainersVersion")}")
+    testImplementation("org.testcontainers:testcontainers-junit-jupiter")
+    testImplementation("org.testcontainers:testcontainers-postgresql")
+    testImplementation("org.testcontainers:testcontainers-r2dbc")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Faker
-    implementation("net.datafaker:datafaker:1.8.1")
+    implementation("net.datafaker:datafaker:2.7.0")
 
     // Netty native libraries for MacOS
     if (System.getProperty("os.name").lowercase().contains("mac")) {
-        implementation("io.netty:netty-resolver-dns-native-macos:4.2.16.Final:osx-aarch_64")
-        implementation("io.netty:netty-resolver-dns-native-macos:4.2.16.Final:osx-x86_64")
+        // Version comes from the Spring Boot BOM so the natives stay in lockstep
+        // with the rest of Netty; they are one artifact set and must not diverge.
+        implementation("io.netty:netty-resolver-dns-native-macos::osx-aarch_64")
+        implementation("io.netty:netty-resolver-dns-native-macos::osx-x86_64")
     }
 }
 
-dependencyManagement {
-    imports {
-        mavenBom("org.testcontainers:testcontainers-bom:${property("testcontainersVersion")}")
-    }
-}
-
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget = "21"
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property")
     }
 }
 

--- a/db/postgres_init/01-databases.sql
+++ b/db/postgres_init/01-databases.sql
@@ -1,3 +1,0 @@
--- データベースを作成
-CREATE DATABASE test
-WITH ENCODING 'UTF8';

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -8,8 +8,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      # POSTGRES_DB above already creates the `test` database on first start.
       - ./db/postgres_data:/var/lib/postgresql/data
-      - ./db/postgres_init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U test"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      # POSTGRES_DB above already creates the `test` database on first start.
       - ./db/postgres_data:/var/lib/postgresql/data
-      - ./db/postgres_init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U test"]
       interval: 30s

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-25.0.3+9.0.LTS"

--- a/src/main/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/handlers/TodoHandler.kt
+++ b/src/main/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/handlers/TodoHandler.kt
@@ -60,6 +60,12 @@ class TodoHandler(val repository: TodoRepository) {
     suspend fun edit(request: ServerRequest): ServerResponse = coroutineScope {
         return@coroutineScope runCatching {
             val todo = request.awaitBody<Todo>()
+            // Spring Data R2DBC 4 silently no-ops an update that matches no row, so an
+            // unknown id has to be rejected explicitly to keep returning 404.
+            val id = todo.id
+            if (id != null && !repository.existsById(id)) {
+                throw NoSuchElementException("Todo id $id does not exist")
+            }
             repository.save(todo)
         }.fold(
             onSuccess = {

--- a/src/main/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/models/Todo.kt
+++ b/src/main/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/models/Todo.kt
@@ -1,7 +1,6 @@
 package com.sennproject.springbootwebfluxkotlincoroutine.models
 
 import io.swagger.v3.oas.annotations.media.Schema
-import lombok.NoArgsConstructor
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
@@ -9,7 +8,6 @@ import java.time.LocalDateTime
 /**
  * @author Yasuyuki Takeo
  */
-@NoArgsConstructor
 @Table("todos")
 data class Todo(
     @Id

--- a/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/AbstractContainerBaseTest.kt
+++ b/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/AbstractContainerBaseTest.kt
@@ -3,15 +3,15 @@ package com.sennproject.springbootwebfluxkotlincoroutine
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
-import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 
 @Testcontainers
 abstract class AbstractContainerBaseTest {
     companion object {
-        val postgres: PostgreSQLContainer<*> =
-            PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:15")).apply {
+        val postgres: PostgreSQLContainer =
+            PostgreSQLContainer(DockerImageName.parse("postgres:15")).apply {
                 withUsername("test")
                 withPassword("password")
                 withDatabaseName("test")

--- a/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/repositories/TodoRepositoryTest.kt
+++ b/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/repositories/TodoRepositoryTest.kt
@@ -2,7 +2,8 @@ package com.sennproject.springbootwebfluxkotlincoroutine.repositories
 
 import com.sennproject.springbootwebfluxkotlincoroutine.AbstractContainerBaseTest
 import com.sennproject.springbootwebfluxkotlincoroutine.models.Todo
-import io.kotest.core.annotation.DoNotParallelize
+import io.kotest.core.annotation.Isolate
+import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row
@@ -19,15 +20,15 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.testcontainers.junit.jupiter.Testcontainers
 
+@ApplyExtension(SpringExtension::class)
 @Testcontainers
 @SpringBootTest(
     properties = ["spring.main.web-application-type=reactive"],
     args = ["-opt-in=kotlin.RequiresOptIn"])
-@DoNotParallelize
+@Isolate
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = [AbstractContainerBaseTest.Initializer::class])
 class TodoRepositoryTest : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
 
     @Autowired
     private lateinit var todoRepository: TodoRepository

--- a/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/routers/TodoRoutesTest.kt
+++ b/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/routers/TodoRoutesTest.kt
@@ -4,8 +4,8 @@ import com.sennproject.springbootwebfluxkotlincoroutine.AbstractContainerBaseTes
 import com.sennproject.springbootwebfluxkotlincoroutine.models.Todo
 import com.sennproject.springbootwebfluxkotlincoroutine.repositories.TodoRepository
 import com.sennproject.springbootwebfluxkotlincoroutine.utils.TodoTestUtils
-import io.kotest.core.annotation.AutoScan
-import io.kotest.core.annotation.DoNotParallelize
+import io.kotest.core.annotation.Isolate
+import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
@@ -23,18 +23,17 @@ import org.testcontainers.junit.jupiter.Testcontainers
 import reactor.core.publisher.Mono
 
 
-@AutoScan
+@ApplyExtension(SpringExtension::class)
 @Testcontainers
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = ["spring.main.web-application-type=reactive"],
     args = ["-opt-in=kotlin.RequiresOptIn"]
 )
-@DoNotParallelize
+@Isolate
 @ActiveProfiles("test")
 @ContextConfiguration(initializers = [AbstractContainerBaseTest.Initializer::class])
 class TodoRoutesTest : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
 
     @Autowired
     private lateinit var todoRepository: TodoRepository


### PR DESCRIPTION
## Summary

Moves the stack to Spring Boot 4.1.0, Kotlin 2.3.21 and Java 25, and pins the JDK in `mise.toml` so local and CI builds resolve the same toolchain. Two faults are fixed along the way: a behavioural regression introduced by Spring Data R2DBC 4, where `PATCH /todos` with an unknown id silently succeeded instead of returning 404, and a pre-existing one that stopped the local Postgres container from starting on a clean checkout.

## Background / Motivation

- The build was pinned to Spring Boot 3.4.2 / Kotlin 1.9.25 / Java 21 while the 4.x line has been out since late 2025; Spring Boot 4.1 is the currently supported target.
- Several dependency versions were pinned by hand and had drifted well behind what the Boot BOM manages — `netty-resolver-dns-native-macos` was still on `4.1.68.Final`, `r2dbc-postgresql` on `1.0.7.RELEASE`, `datafaker` on `1.8.1`.
- No JDK version was recorded in the repository. `README.md` said "Java 21", the CI workflow hardcoded `java-version: '21'` in a separate place, and nothing pinned a local JDK, so the three could drift independently.
- The build carried dependencies nothing used: Lombok (there is not a single `.java` source, and `@NoArgsConstructor` on a Kotlin `data class` is a no-op), `spring-cloud-function-web`, and the `org.openapi.generator` plugin, which was applied but never configured.
- `make devDB` and `make genapi` could not work from a clean checkout — the Postgres container exited during its first start, long before any of this upgrade was involved.

## Changes

### Toolchain pinned with mise

- New `mise.toml` pinning `java = "temurin-25.0.3+9.0.LTS"`; `mise install` provisions the JDK and sets `JAVA_HOME`.
- `build.gradle.kts` replaces `java.sourceCompatibility = JavaVersion.VERSION_21` with a `java { toolchain { languageVersion = JavaLanguageVersion.of(25) } }` block, so the JDK is resolved by Gradle rather than inherited from the ambient environment.
- `gradle-wrapper.properties` moves to Gradle 9.5.1, required for Java 25 and Spring Boot 4.
- `.github/workflows/spring-boot-webflux-kotlin-coroutine.yml` drops `actions/setup-java` in favour of `jdx/mise-action@v4`, making `mise.toml` the single source of truth for the JDK.

### Spring Boot 4 and Jackson 3

- Spring Boot plugin and BOM `3.4.2` → `4.1.0` (Spring Framework 7.0.8); Kotlin `jvm`/`plugin.spring` `1.9.25` → `2.3.21`, the version Spring Boot 4.1 manages through `kotlin.version`, so the plugin and the BOM agree.
- Jackson 3 group relocation: `com.fasterxml.jackson.module:jackson-module-kotlin` → `tools.jackson.module:jackson-module-kotlin`. The duplicate declaration of that artifact is removed.
- `springdoc-openapi-starter-webflux-ui` `2.8.4` → `3.0.3`, the release line built against Spring Boot 4.
- `kotlinOptions` / `tasks.withType<KotlinCompile>` replaced by the `kotlin { compilerOptions { … } }` DSL; `jvmTarget` now derives from the toolchain. `-Xannotation-default-target=param-property` joins `-Xjsr305=strict`, matching what start.spring.io emits for this Boot/Kotlin pairing.
- Hand-pinned versions handed back to the Boot BOM: `r2dbc-pool`, `r2dbc-postgresql`, `kotlinx-coroutines-core`, `kotlinx-coroutines-test`, the Testcontainers BOM import, and the macOS Netty natives (now resolved to `4.2.15.Final` via the classifier-only `io.netty:netty-resolver-dns-native-macos::osx-aarch_64` form).

### Unknown-id updates keep returning 404

- Spring Data R2DBC changed how a zero-row update is reported. In 3.4.2, `R2dbcEntityTemplate` raised `TransientDataAccessResourceException` when an update matched no row on a non-versioned entity; in 4.1.0 that path only raises for entities with a `@Version` property and is otherwise a silent no-op.
- `TodoHandler.edit` relied on that exception to map an unknown id to 404, so after the upgrade `PATCH /todos` with a non-existent id returned 200 and quietly changed nothing. It now checks `repository.existsById(id)` before saving and throws when the row is absent, restoring the previous contract.

### Test stack: Kotest 6 and Testcontainers 2

- Kotest `5.9.1` → `6.2.2`. Extensions consolidated under the `io.kotest` group, so `io.kotest.extensions:kotest-extensions-spring:1.1.3` → `io.kotest:kotest-extensions-spring:6.2.2`. This supersedes Renovate's bump of the old coordinate to 1.3.0 on `develop`, which this branch drops.
- `@AutoScan` plus `override fun extensions() = listOf(SpringExtension)` is gone in Kotest 6; both specs now use `@ApplyExtension(SpringExtension::class)`. `@DoNotParallelize` is deprecated in favour of `@Isolate`.
- `kotest-assertions-table` added for the `io.kotest.data.blocking.forAll` / `row` usage in `TodoRepositoryTest`, which is no longer bundled in core.
- Testcontainers 2.0 renamed every module with a `testcontainers-` prefix (`junit-jupiter` → `testcontainers-junit-jupiter`, and likewise for `postgresql` and `r2dbc`), and relocated `PostgreSQLContainer` to `org.testcontainers.postgresql`, where it is no longer self-typed — `AbstractContainerBaseTest` drops the `<Nothing>` / `<*>` type arguments.
- The monolithic `spring-boot-starter-test` is replaced by the modular `spring-boot-starter-webflux-test` and `spring-boot-starter-data-r2dbc-test`, plus an explicit `junit-platform-launcher` at test runtime.

### Postgres container no longer exits on first start

- `db/postgres_init/01-databases.sql` ran `CREATE DATABASE test`, but `POSTGRES_DB: test` already makes the official image create that database. On a first start the script failed with `database "test" already exists`, which aborts the entrypoint and exits the container. Existing checkouts hid this because init scripts only run against an empty data directory.
- Unsetting `POSTGRES_DB` would not help — it defaults to `POSTGRES_USER`, which is also `test` — and Postgres has no `CREATE DATABASE IF NOT EXISTS`. Since the script only duplicated what `POSTGRES_DB` already does, it is removed along with the now-empty `/docker-entrypoint-initdb.d` mount in `docker-compose.yml` and `docker-compose-local.yml`.
- Nothing is lost: the database is still created as UTF8 (the official image's default), and the `todos` table is still created by `ConnectionFactoryInitializer` from `db/tables.sql` at application start.

### Dependency cleanup

- Removed Lombok (`compileOnly` + `annotationProcessor`) and the `@NoArgsConstructor` import in `Todo.kt`.
- Removed `spring-cloud-function-web` and the unconfigured `org.openapi.generator` plugin.
- Removed `kotlin-stdlib-jdk8`, which has been folded into `kotlin-stdlib` since Kotlin 2.x and is contributed by the Kotlin plugin.
- `datafaker` `1.8.1` → `2.7.0`.

### Docker and docs

- `Dockerfile`: builder `gradle:8.12-jdk21-alpine` → `gradle:9.5.1-jdk25`, runtime `eclipse-temurin:21.0.11_10-jdk-ubi9-minimal` → `eclipse-temurin:25.0.3_9-jdk-ubi10-minimal`. Temurin publishes no ubi9 variant for 25, and the exact-tag pin follows the convention Renovate established on `develop`; the tag matches the JDK pinned in `mise.toml`. `as builder` capitalised to silence the BuildKit warning.
- `README.md` records Java 25, Gradle 9.5.1 and the Spring Boot 4.1 / Kotlin 2.3 stack, and documents `mise trust && mise install`.

## Verification

With Docker running, `./gradlew clean build` provisions Postgres via Testcontainers, boots the real reactive server on a random port and exercises the routes end to end, including a `/swagger-ui/index.html` fetch. The startup banner in the test log should read `:: Spring Boot :: (v4.1.0)`, and `build/libs/spring-boot-webflux-kotlin-coroutine-1.0.0.jar` should contain `BOOT-INF/lib/netty-resolver-dns-native-macos-4.2.15.Final-osx-aarch_64.jar`, confirming the BOM is supplying the native classifier.

The 404 fix is the one behavioural change worth exercising by hand: `PATCH /todos` with a body whose `id` does not exist must come back 404, while a `POST /todos` with `"id": null` must still insert and return 200.

For the container fix, the check that matters is a genuinely clean start — `rm -rf db/postgres_data` first, since init scripts only run against an empty data directory and a populated one masks the fault.

## Test plan

- [ ] `mise trust && mise install && mise exec -- java -version` reports `openjdk version "25.0.3"`.
- [ ] `./gradlew dependencies --configuration runtimeClasspath | grep kotlin-stdlib` resolves to 2.3.21, matching the Boot 4.1 BOM.
- [ ] `./gradlew clean build` is green — 12 tests, 0 failures (8 in `TodoRoutesTest`, 4 in `TodoRepositoryTest`).
- [ ] `rm -rf db/postgres_data && make devDB` leaves the container `running (healthy)` instead of exiting, and `psql -U test -d test -c "select 1"` succeeds inside it.
- [ ] `SPRING_PROFILES_ACTIVE=local ./gradlew generateOpenApiDocs` succeeds against that container and `build/openapi.json` lists `/todos` (get, patch, post), `/todos/{id}` (get, delete) and the `Todo` schema.
- [ ] Regression: `PATCH /todos` with an id that is not in the table returns 404, not 200, and leaves the row count unchanged (covered by `TodoRoutesTest > Edit Error test`).
- [ ] Regression: `POST /todos` with `"id": null` still inserts and returns 2xx (covered by `TodoRoutesTest > Add Smoke test`).
- [ ] CI on this PR shows the `Run Test` job resolving the JDK through `jdx/mise-action` rather than `actions/setup-java`.
