### PR TITLE
Update CI actions to latest and remove duplicate Codecov step

### DIFF
--- a/.github/workflows/spring-boot-webflux-kotlin-coroutine.yml
+++ b/.github/workflows/spring-boot-webflux-kotlin-coroutine.yml
@@ -16,19 +16,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '21'
 
       - name: Install dependencies, run tests, and collect coverage
         run: ./gradlew clean build
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7


### PR DESCRIPTION
## Summary

Every action in the CI workflow was pinned to `@v3`, all of which declare the retired Node 16 runtime. This bumps each one to its current major and deletes a stray Codecov step that ran before checkout, leaving a four-step job: check out, set up Java 21, build, upload coverage.

## Background / Motivation

- `actions/checkout@v3`, `actions/setup-java@v3` and `codecov/codecov-action@v3` all declare `runs.using: node16`. GitHub has retired that runtime, so these steps rely on the forced Node 20 fallback and emit deprecation warnings.
- The job's first step was `Upload coverage reports to Codecov`, placed *before* `Checkout code`. It ran against an empty workspace, before the build had produced any coverage report, and duplicated the correct `Upload coverage to Codecov` step at the end of the job.
- Renovate (enabled in #2) classifies `v3` to `v7` as a major update, so it would raise these as PRs that never automerge and wait for a human regardless. Bumping them together in one reviewed PR clears that backlog up front.

## Changes

### Action version bumps

- `actions/checkout`: `@v3` to `@v7` — `node16` to `node24`.
- `actions/setup-java`: `@v3` to `@v5` — `node16` to `node24`. The `distribution: temurin` and `java-version: '21'` inputs are unchanged and remain valid.
- `codecov/codecov-action`: `@v3` to `@v7` — `node16` to a composite action.

### Duplicate Codecov step removed

- Dropped the `Upload coverage reports to Codecov` step that preceded `Checkout code`. The `Upload coverage to Codecov` step following the Gradle build is retained and is now the only uploader.

## Verification

The workflow parses to exactly four steps, in the right order:

```
python3 -c "
import yaml
d = yaml.safe_load(open('.github/workflows/spring-boot-webflux-kotlin-coroutine.yml'))
for s in d['jobs']['test']['steps']: print(s.get('name'), '|', s.get('uses') or s.get('run'))
"
# Checkout code | actions/checkout@v7
# Set up Java | actions/setup-java@v5
# Install dependencies, run tests, and collect coverage | ./gradlew clean build
# Upload coverage to Codecov | codecov/codecov-action@v7
```

`grep -rn 'uses:' .github/` returns only those three pins — no `@v3` is left anywhere in the repository.

In this PR's own `Run Test` check, the job log should carry no Node 16 deprecation warning, and Codecov should be invoked once rather than twice.

## Test plan

- [ ] `Run Test` passes on this PR.
- [ ] The job log shows no `Node.js 16 actions are deprecated` warning.
- [ ] `Set up Java` still provisions Temurin 21 and `./gradlew clean build` succeeds.
- [ ] Coverage lands on Codecov for this commit, uploaded by a single step.
- [ ] `grep -rn 'uses:' .github/` shows no action pinned below its current major.

## Notes

This repository is public, so `codecov/codecov-action@v7` uploads tokenless via OIDC and needs no `CODECOV_TOKEN` secret. Should the repository ever become private, that step will need a `token:` input wired to a repository secret.
