### PR TITLE
Upgrade PostgreSQL from 15 to 18 and clean up MySQL leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 ![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/yasuflatland-lf/spring-boot-webflux-kotlin-coroutine/spring-boot-webflux-kotlin-coroutine.yml?branch=develop)
 [![codecov](https://codecov.io/github/yasuflatland-lf/spring-boot-webflux-kotlin-coroutine/branch/develop/graph/badge.svg?token=Kj9b0BQZcV)](https://codecov.io/github/yasuflatland-lf/spring-boot-webflux-kotlin-coroutine)
 
-A sample of Spring boot WebFlux and Kotlin Coroutine with Handler and Router. In this sample, implementing Todo model, handler and router with database (MySQL) testing.
+A sample of Spring boot WebFlux and Kotlin Coroutine with Handler and Router. In this sample, implementing Todo model, handler and router with database (PostgreSQL) testing.
 
 # Reqirements
 - Java 25 (managed by [mise](https://mise.jdx.dev/))
 - Docker 4.37.2 >=
 - gradle 9.5.1 (provided by the Gradle wrapper)
+- PostgreSQL 18 (spun up by `docker-compose`, and by Testcontainers for tests)
 
 Spring Boot 4.1 / Kotlin 2.3 / Spring Framework 7.
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:15
+    image: postgres:18
     environment:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:15
+    image: postgres:18
     environment:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: password

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,10 +1,9 @@
 server:
   port: 8080
 
-  r2dbc:
-    url: ""
-    username: "root"
-    password: "password"
+spring:
+  # spring.r2dbc.* is deliberately absent: AbstractContainerBaseTest.Initializer injects it
+  # from the Testcontainers instance, whose port is only known at runtime.
   main:
     allow-bean-definition-overriding: true
 

--- a/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/AbstractContainerBaseTest.kt
+++ b/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/AbstractContainerBaseTest.kt
@@ -11,7 +11,7 @@ import org.testcontainers.utility.DockerImageName
 abstract class AbstractContainerBaseTest {
     companion object {
         val postgres: PostgreSQLContainer =
-            PostgreSQLContainer(DockerImageName.parse("postgres:15")).apply {
+            PostgreSQLContainer(DockerImageName.parse("postgres:18")).apply {
                 withUsername("test")
                 withPassword("password")
                 withDatabaseName("test")

--- a/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/repositories/TodoRepositoryTest.kt
+++ b/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/repositories/TodoRepositoryTest.kt
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDateTime
 
 @ApplyExtension(SpringExtension::class)
 @Testcontainers
@@ -79,6 +80,31 @@ class TodoRepositoryTest : FunSpec() {
                     result.count() shouldBe amount
                 }
             }
+        }
+
+        test("findById") {
+            var todo = Todo(null)
+            todo.task = "test"
+            val saved = todoRepository.save(todo)
+
+            val result = todoRepository.findById(saved.id!!)
+            result shouldNotBe null
+            result?.id shouldBe saved.id
+            result?.task shouldBe "test"
+        }
+
+        // todos.created_at / updated_at are TIMESTAMPTZ while Todo maps them to LocalDateTime,
+        // so the driver has to apply and strip an offset. A fixed timestamp keeps this from
+        // passing on precision alone.
+        test("Timestamps survive a TIMESTAMPTZ round trip") {
+            val fixed = LocalDateTime.of(2026, 1, 2, 3, 4, 5)
+            var todo = Todo(null, created_at = fixed, updated_at = fixed)
+            todo.task = "test"
+            val saved = todoRepository.save(todo)
+
+            val result = todoRepository.findById(saved.id!!)
+            result?.created_at shouldBe fixed
+            result?.updated_at shouldBe fixed
         }
 
         test("findAllByStatusEquals failure pattern") {

--- a/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/routers/TodoRoutesTest.kt
+++ b/src/test/kotlin/com/sennproject/springbootwebfluxkotlincoroutine/routers/TodoRoutesTest.kt
@@ -215,6 +215,51 @@ class TodoRoutesTest : FunSpec() {
 
         }
 
+        test("Get a todo by id Smoke test") {
+            var todo = Todo(null)
+            todo.task = "find me"
+            todo.status = true
+            val result = todoRepository.save(todo)
+
+            WebTestClient
+                .bindToServer()
+                .baseUrl("http://localhost:$port")
+                .build()
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder
+                        .pathSegment("todos", result.id.toString())
+                        .build()
+                }
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk
+                .expectBody<Todo>()
+                .consumeWith { response ->
+                    response.responseBody?.id shouldBe result.id
+                    response.responseBody?.task shouldBe "find me"
+                    response.responseBody?.status shouldBe true
+                }
+        }
+
+        test("Get a todo by unknown id Error test") {
+            WebTestClient
+                .bindToServer()
+                .baseUrl("http://localhost:$port")
+                .build()
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder
+                        .pathSegment("todos", "999999")
+                        .build()
+                }
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNotFound
+        }
+
         test("Access OpenAPI UI") {
             WebTestClient
                 .bindToServer()


### PR DESCRIPTION
## Summary

Moves PostgreSQL from 15 to 18, the current stable major, across both compose files and Testcontainers. Along the way it clears the two leftovers the original MySQL-to-PostgreSQL migration never swept up — a stale README line and dead `root` credentials in `application-test.yml` — and adds integration coverage for `GET /todos/{id}`, which has a route, a handler and a Swagger definition but had no test at all.

## Background / Motivation

- The MySQL-to-PostgreSQL migration landed in `14c82fa`, which introduced `r2dbc-postgresql` and pinned `postgres:15`. PostgreSQL 15 shipped in October 2022 and reaches EOL in November 2027; 18 has been the stable major since September 2025 (latest minor 18.4, supported until November 2030). PostgreSQL 19 is still in beta as of this PR and is not a candidate.
- That migration left `README.md` describing the sample as testing "with database (MySQL)" — the last MySQL reference anywhere in the repository.
- `application-test.yml` nested `r2dbc` and `main` under `server:` rather than `spring:`, so the entire block was dead config that Spring never read. It still carried `username: "root"` — a MySQL-era credential that does not even match the PostgreSQL user (`test`). The tests pass only because `AbstractContainerBaseTest.Initializer` injects `spring.r2dbc.*` from the Testcontainers instance, which takes precedence regardless.
- `GET /todos/{id}` is routed to `TodoHandler.findById` and documented in `@RouterOperations`, but neither spec exercised it, leaving the `ServerResponse.notFound()` branch unreached. The other four routes all have tests.
- `todos.created_at` and `updated_at` are `TIMESTAMPTZ` while `Todo` maps them to `LocalDateTime`, so the driver applies and strips an offset on every round trip. Nothing asserted the value survives it — the one mapping a PostgreSQL major bump could plausibly disturb.

## Changes

### PostgreSQL 15 to 18

- `docker-compose.yml` and `docker-compose-local.yml`: `image: postgres:15` to `postgres:18`.
- `AbstractContainerBaseTest`: the Testcontainers image follows to `postgres:18`, keeping the test database on the same major the compose files run.
- Pinned to the major tag rather than `18.4`, matching the existing `postgres:15` convention. Renovate automerges minor and patch from there per `renovate.json`, while a future major would surface as a `major-update` PR for review.
- No `pg_upgrade` path is involved: `db/postgres_data/` is gitignored and created on first start, so 18 enabling data checksums by default and recording `char` signedness never meet a pre-18 data directory. The md5 password deprecation does not apply either — the official image initialises with scram-sha-256.

### MySQL leftovers removed

- `README.md`: "database (MySQL) testing" to "database (PostgreSQL) testing", and the requirements list gains PostgreSQL 18 alongside Java 25, Docker and Gradle.
- `application-test.yml`: the `r2dbc` block, `username: "root"` included, is deleted rather than re-nested under `spring:`. Re-nesting would activate `url: ""` and the wrong credentials for the first time; the block has no reason to exist, since the connection details are only knowable at runtime from the Testcontainers port.

### application-test.yml nesting fixed

- `main.allow-bean-definition-overriding` moves from under `server:` to `spring:`, where it was always meant to be. Behaviour is unchanged — `application.yml` already sets the same key and the `test` profile layers over it — which the suite confirms.
- A comment records why `spring.r2dbc.*` is deliberately absent, so the block is not helpfully restored later.

### Tests

- `TodoRoutesTest > Get a todo by id Smoke test`: saves a row, fetches `/todos/{id}`, asserts 200 and that id, task and status survive the round trip.
- `TodoRoutesTest > Get a todo by unknown id Error test`: asserts `/todos/999999` returns 404, covering the previously unreached `notFound()` branch.
- `TodoRepositoryTest > findById`: the repository-level counterpart.
- `TodoRepositoryTest > Timestamps survive a TIMESTAMPTZ round trip`: writes a fixed `LocalDateTime.of(2026, 1, 2, 3, 4, 5)` and reads it back. A fixed value rather than `now()` keeps the assertion from passing on precision alone and pins the `TIMESTAMPTZ` to `LocalDateTime` offset handling.
- 12 tests to 16 — `TodoRoutesTest` 8 to 10, `TodoRepositoryTest` 4 to 6.

## Verification

The container runs a genuine 18, not a retagged 15:

```
rm -rf db/postgres_data && make devDB
docker compose -f docker-compose-local.yml exec postgres psql -U test -d test -c 'select version()'
# PostgreSQL 18.x ...
```

The clean `db/postgres_data` matters here — a data directory populated by 15 makes an 18 container refuse to start, so a stale local checkout would mask the upgrade rather than exercise it.

`grep -rin mysql . --exclude-dir=.git` should return no hits.

For the suite, `./gradlew clean build` provisions `postgres:18` via Testcontainers and boots the real reactive server on a random port. The `TIMESTAMPTZ` round trip is the assertion worth watching: it fails if the driver's offset handling regresses under the new major.

## Test plan

- [ ] `./gradlew clean build` is green — 16 tests, 0 failures (10 in `TodoRoutesTest`, 6 in `TodoRepositoryTest`).
- [ ] `rm -rf db/postgres_data && make devDB` leaves the container `running (healthy)`, and `select version()` inside it reports PostgreSQL 18.
- [ ] `GET /todos/{id}` with an existing id returns 200 with the row (covered by `TodoRoutesTest > Get a todo by id Smoke test`).
- [ ] `GET /todos/{id}` with an unknown id returns 404 (covered by `TodoRoutesTest > Get a todo by unknown id Error test`).
- [ ] A saved `created_at` / `updated_at` reads back identical (covered by `TodoRepositoryTest > Timestamps survive a TIMESTAMPTZ round trip`).
- [ ] Regression: `PATCH /todos` with an unknown id still returns 404 (covered by `TodoRoutesTest > Edit Error test`).
- [ ] Regression: `POST /todos` with `"id": null` still inserts and returns 2xx (covered by `TodoRoutesTest > Add Smoke test`).
- [ ] `grep -rin mysql . --exclude-dir=.git` returns no hits.
- [ ] `make run` boots the app against the 18 container and `/todos` responds.
